### PR TITLE
Feature/loading

### DIFF
--- a/src/Components/Loader/Round/index.jsx
+++ b/src/Components/Loader/Round/index.jsx
@@ -1,7 +1,24 @@
 import React from 'react';
 
 function RoundLoader() {
-  return <div className="roundLoader">This is RoundLoader Component</div>;
+  return (
+    <div className="roundLoader">
+      <div className="roundLoader__spinner">
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+        <div className="roundLoader__spinner-blade" />
+      </div>
+    </div>
+  );
 }
 
 export default RoundLoader;

--- a/src/Components/Loader/Round/index.jsx
+++ b/src/Components/Loader/Round/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function RoundLoader() {
+  return <div className="roundLoader">This is RoundLoader Component</div>;
+}
+
+export default RoundLoader;

--- a/src/Components/Loader/Round/index.jsx
+++ b/src/Components/Loader/Round/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function RoundLoader() {
   return (
-    <div className="roundLoader">
+    <div className="roundLoader overlay">
       <div className="roundLoader__spinner">
         <div className="roundLoader__spinner-blade" />
         <div className="roundLoader__spinner-blade" />

--- a/src/Components/Loader/Round/index.scss
+++ b/src/Components/Loader/Round/index.scss
@@ -3,5 +3,48 @@
 */
 
 .roundLoader {
-  color: $main-color;
+  @include content-full;
+
+  &.overlay {
+    background-color: rgba($color: $black, $alpha: 0.2);
+  }
+
+  &__spinner {
+    @include absolute-center;
+    width: 3rem;
+    height: 3rem;
+
+    &-blade {
+      width: 0.3rem;
+      height: 1.2rem;
+      border-radius: 30%;
+      background-color: transparent;
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform-origin: center -60%;
+      animation: spinner-fade 1s infinite linear;
+
+      $animation-delay: 0s;
+      $blade-rotation: 0deg;
+      @for $i from 1 through 12 {
+        &:nth-child(#{$i}) {
+          animation-delay: $animation-delay;
+          transform: rotate($blade-rotation);
+          $blade-rotation: $blade-rotation + 30;
+          $animation-delay: $animation-delay + 0.083;
+        }
+      }
+    }
+  }
+}
+
+@keyframes spinner-fade {
+  0% {
+    background-color: $main-color;
+  }
+
+  100% {
+    background-color: transparent;
+  }
 }

--- a/src/Components/Loader/Round/index.scss
+++ b/src/Components/Loader/Round/index.scss
@@ -1,0 +1,7 @@
+/*
+  Round Loader Component Styling
+*/
+
+.roundLoader {
+  color: $main-color;
+}

--- a/src/Components/Loader/Round/index.scss
+++ b/src/Components/Loader/Round/index.scss
@@ -4,6 +4,7 @@
 
 .roundLoader {
   @include content-full;
+  z-index: 9999;
 
   &.overlay {
     background-color: rgba($color: $black, $alpha: 0.2);

--- a/src/Components/Sign/SignInForm/index.jsx
+++ b/src/Components/Sign/SignInForm/index.jsx
@@ -6,6 +6,7 @@ import * as AuthAction from 'Redux/auth';
 
 import RoundInput from 'Components/Form/RoundInput';
 import Button from 'Components/Form/Button';
+import RoundLoader from 'Components/Loader/Round';
 import { DEFAULT_HELPER_TEXT, SignInHelperText } from 'Constants/helper-text';
 
 const propTypes = {
@@ -32,6 +33,7 @@ class SignInForm extends Component {
         isValid: true,
         helperText: DEFAULT_HELPER_TEXT,
       },
+      loading: false,
     };
   }
 
@@ -64,6 +66,7 @@ class SignInForm extends Component {
   handleSignIn = async () => {
     const { dispatch } = this.props;
     const { id, password } = this.state;
+    this.setState({ loading: true });
     if (id.value === '' || password.value === '') {
       if (id.value === '') {
         this.setState({
@@ -103,10 +106,11 @@ class SignInForm extends Component {
         });
       }
     }
+    this.setState({ loading: false });
   };
 
   render() {
-    const { id, password } = this.state;
+    const { id, password, loading } = this.state;
     return (
       <form className="signInForm">
         <div className="signInForm__input">
@@ -140,6 +144,7 @@ class SignInForm extends Component {
             onClick={() => this.handleSignIn()}
           />
         </div>
+        {loading ? <RoundLoader /> : null}
       </form>
     );
   }

--- a/src/Components/Sign/SignInForm/index.jsx
+++ b/src/Components/Sign/SignInForm/index.jsx
@@ -6,16 +6,26 @@ import * as AuthAction from 'Redux/auth';
 
 import RoundInput from 'Components/Form/RoundInput';
 import Button from 'Components/Form/Button';
-import RoundLoader from 'Components/Loader/Round';
 import { DEFAULT_HELPER_TEXT, SignInHelperText } from 'Constants/helper-text';
 
 const propTypes = {
-  dispatch: PropTypes.func.isRequired,
+  postSignIn: PropTypes.func.isRequired,
+  getUser: PropTypes.func.isRequired,
+  setLoadingState: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
   return {
     token: state.authReducer.token,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    postSignIn: (userData) => dispatch(AuthAction.postSignIn(userData)),
+    getUser: (token) => dispatch(AuthAction.getUser(token)),
+    setLoadingState: (loadingState) =>
+      dispatch(AuthAction.setLoadingState(loadingState)),
   };
 };
 
@@ -33,7 +43,6 @@ class SignInForm extends Component {
         isValid: true,
         helperText: DEFAULT_HELPER_TEXT,
       },
-      loading: false,
     };
   }
 
@@ -64,9 +73,9 @@ class SignInForm extends Component {
   };
 
   handleSignIn = async () => {
-    const { dispatch } = this.props;
+    const { postSignIn, getUser, setLoadingState } = this.props;
     const { id, password } = this.state;
-    this.setState({ loading: true });
+    setLoadingState(true);
     if (id.value === '' || password.value === '') {
       if (id.value === '') {
         this.setState({
@@ -88,9 +97,9 @@ class SignInForm extends Component {
       }
     } else {
       const userData = { id: id.value, password: password.value };
-      const token = await dispatch(AuthAction.postSignIn(userData));
+      const token = await postSignIn(userData);
       if (token) {
-        await dispatch(AuthAction.getUser(token));
+        await getUser(token);
       } else {
         this.setState({
           id: {
@@ -106,11 +115,11 @@ class SignInForm extends Component {
         });
       }
     }
-    this.setState({ loading: false });
+    setLoadingState(false);
   };
 
   render() {
-    const { id, password, loading } = this.state;
+    const { id, password } = this.state;
     return (
       <form className="signInForm">
         <div className="signInForm__input">
@@ -144,7 +153,6 @@ class SignInForm extends Component {
             onClick={() => this.handleSignIn()}
           />
         </div>
-        {loading ? <RoundLoader /> : null}
       </form>
     );
   }
@@ -152,4 +160,4 @@ class SignInForm extends Component {
 
 SignInForm.propTypes = propTypes;
 
-export default connect(mapStateToProps)(SignInForm);
+export default connect(mapStateToProps, mapDispatchToProps)(SignInForm);

--- a/src/Components/Sign/SignUpContainer/index.jsx
+++ b/src/Components/Sign/SignUpContainer/index.jsx
@@ -13,14 +13,24 @@ import RoundLoader from 'Components/Loader/Round';
 
 const defaultProps = {};
 const propTypes = {
+  authLoading: PropTypes.bool.isRequired,
   createUser: PropTypes.func.isRequired,
   signInUser: PropTypes.func.isRequired,
+  setLoadingState: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = (state) => {
+  return {
+    authLoading: state.authReducer.loading,
+  };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
     createUser: (user) => dispatch(AuthAction.postUser(user)),
     signInUser: (userInfo) => dispatch(AuthAction.postSignIn(userInfo)),
+    setLoadingState: (loadingState) =>
+      dispatch(AuthAction.setLoadingState(loadingState)),
   };
 };
 
@@ -30,7 +40,6 @@ class SignUpContainer extends Component {
     this.state = {
       user: {},
       isValid: false,
-      loading: false,
     };
   }
 
@@ -48,21 +57,24 @@ class SignUpContainer extends Component {
   };
 
   handleSignUp = async () => {
-    const { createUser, signInUser } = this.props;
+    const { createUser, signInUser, setLoadingState } = this.props;
     const { user } = this.state;
 
-    this.setState({ loading: true });
+    setLoadingState(true);
     await createUser(user);
     await signInUser({ id: user.email, password: user.password });
-    this.setState({ loading: false });
+    setLoadingState(false);
 
     window.location.reload('/');
   };
 
   render() {
-    const { isValid, loading } = this.state;
+    const { authLoading } = this.props;
+    const { isValid } = this.state;
+
     return (
       <div className="signUpContainer">
+        {authLoading && <RoundLoader />}
         <div className="signUpContainer__form">
           <div className="signUpContainer__form-linked">
             <SignFacebook isSignUp />
@@ -97,7 +109,6 @@ class SignUpContainer extends Component {
             <a href="/signin">Sign in</a>
           </div>
         </div>
-        {loading ? <RoundLoader /> : null}
       </div>
     );
   }
@@ -106,4 +117,7 @@ class SignUpContainer extends Component {
 SignUpContainer.defaultProps = defaultProps;
 SignUpContainer.propTypes = propTypes;
 
-export default connect(null, mapDispatchToProps)(withRouter(SignUpContainer));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(SignUpContainer));

--- a/src/Components/Sign/SignUpContainer/index.jsx
+++ b/src/Components/Sign/SignUpContainer/index.jsx
@@ -39,6 +39,14 @@ class SignUpContainer extends Component {
     else this.setState({ isValid: false });
   };
 
+  handleEnter = (e) => {
+    const { isValid } = this.state;
+
+    if (isValid && e.key === 'Enter') {
+      this.handleSignUp();
+    }
+  };
+
   handleSignUp = async () => {
     const { createUser, signInUser } = this.props;
     const { user } = this.state;
@@ -65,7 +73,10 @@ class SignUpContainer extends Component {
             <span>or</span>
             <hr />
           </div>
-          <SignUpForm handleValidation={this.handleValidation} />
+          <SignUpForm
+            handleValidation={this.handleValidation}
+            handleEnter={(e) => this.handleEnter(e)}
+          />
           <div className="signUpContainer__form-policy">
             <hr />
             <p>

--- a/src/Components/Sign/SignUpContainer/index.jsx
+++ b/src/Components/Sign/SignUpContainer/index.jsx
@@ -9,6 +9,7 @@ import Button from 'Components/Form/Button';
 import SignFacebook from 'Components/Sign/Facebook';
 import SignGoogle from 'Components/Sign/Google';
 import SignUpForm from 'Components/Sign/SignUpForm';
+import RoundLoader from 'Components/Loader/Round';
 
 const defaultProps = {};
 const propTypes = {
@@ -29,6 +30,7 @@ class SignUpContainer extends Component {
     this.state = {
       user: {},
       isValid: false,
+      loading: false,
     };
   }
 
@@ -41,13 +43,16 @@ class SignUpContainer extends Component {
     const { createUser, signInUser } = this.props;
     const { user } = this.state;
 
+    this.setState({ loading: true });
     await createUser(user);
     await signInUser({ id: user.email, password: user.password });
+    this.setState({ loading: false });
+
     window.location.reload('/');
   };
 
   render() {
-    const { isValid } = this.state;
+    const { isValid, loading } = this.state;
     return (
       <div className="signUpContainer">
         <div className="signUpContainer__form">
@@ -81,6 +86,7 @@ class SignUpContainer extends Component {
             <a href="/signin">Sign in</a>
           </div>
         </div>
+        {loading ? <RoundLoader /> : null}
       </div>
     );
   }

--- a/src/Components/Sign/SignUpForm/index.jsx
+++ b/src/Components/Sign/SignUpForm/index.jsx
@@ -14,6 +14,7 @@ import { INIT, USER_API, QUERY_EMAIL, QUERY_NAME } from 'Constants/api-uri';
 
 const propTypes = {
   handleValidation: PropTypes.func.isRequired,
+  handleEnter: PropTypes.func.isRequired,
 };
 
 class SignUpForm extends Component {
@@ -223,6 +224,7 @@ class SignUpForm extends Component {
   };
 
   render() {
+    const { handleEnter } = this.props;
     const { isValid, helperText } = this.state;
 
     return (
@@ -237,6 +239,7 @@ class SignUpForm extends Component {
               helperText={helperText.email}
               InputProps={isValid.email ? <CheckIcon /> : null}
               onChange={(e) => this.handleEmail(e)}
+              onKeyPress={(e) => handleEnter(e)}
             />
           </div>
           <div className="signUpForm__input">
@@ -249,6 +252,7 @@ class SignUpForm extends Component {
               helperText={helperText.name}
               InputProps={isValid.name ? <CheckIcon /> : null}
               onChange={(e) => this.handleName(e)}
+              onKeyPress={(e) => handleEnter(e)}
             />
           </div>
           <div className="signUpForm__input">
@@ -261,6 +265,7 @@ class SignUpForm extends Component {
               helperText={helperText.password}
               InputProps={isValid.password ? <CheckIcon /> : null}
               onChange={(e) => this.handlePassword(e)}
+              onKeyPress={(e) => handleEnter(e)}
             />
           </div>
         </form>

--- a/src/Components/Sign/SignUpForm/index.jsx
+++ b/src/Components/Sign/SignUpForm/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import RoundInput from 'Components/Form/RoundInput';
 import CheckIcon from 'Components/Form/CheckIcon';
-
 import {
   DEFAULT_HELPER_TEXT,
   EmailHelperText,

--- a/src/Constants/colors.scss
+++ b/src/Constants/colors.scss
@@ -13,6 +13,7 @@ $white-gray: #f3f3f3;
 $header-gray: #595959;
 
 $white: #ffffff;
+$black: #000000;
 
 $facebook-blue: #1776f2;
 

--- a/src/Constants/layout.scss
+++ b/src/Constants/layout.scss
@@ -6,6 +6,15 @@
   left: 0;
 }
 
+@mixin absolute-center {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+}
+
 @mixin content-center {
   display: flex;
   flex-direction: column;

--- a/src/Pages/SignInPage/index.jsx
+++ b/src/Pages/SignInPage/index.jsx
@@ -23,8 +23,8 @@ class SignInPage extends Component {
             <span>Already have an account? </span>
             <a href="/signup">Sign Up</a>
           </div>
-          <RoundLoader />
         </div>
+        <RoundLoader />
       </>
     );
   }

--- a/src/Pages/SignInPage/index.jsx
+++ b/src/Pages/SignInPage/index.jsx
@@ -1,31 +1,29 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { useSelector } from 'react-redux';
 
 import NavBar from 'Components/Common/NavBar';
 import SignInContainer from 'Components/Sign/SignInContainer';
+import RoundLoader from 'Components/Loader/Round';
 
-class SignInPage extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
+function SignInPage() {
+  const authLoading = useSelector((state) => state.authReducer.loading);
 
-  render() {
-    return (
-      <>
-        <NavBar isActive="signIn" />
-        <div className="signInPage">
-          <div className="signInPage__header">
-            <p>Welcome to Bletcher</p>
-          </div>
-          <SignInContainer />
-          <div className="signInPage__footer">
-            <span>Already have an account? </span>
-            <a href="/signup">Sign Up</a>
-          </div>
+  return (
+    <>
+      <NavBar isActive="signIn" />
+      <div className="signInPage">
+        <div className="signInPage__header">
+          <p>Welcome to Bletcher</p>
         </div>
-      </>
-    );
-  }
+        <SignInContainer />
+        <div className="signInPage__footer">
+          <span>Already have an account? </span>
+          <a href="/signup">Sign Up</a>
+        </div>
+      </div>
+      {authLoading && <RoundLoader />}
+    </>
+  );
 }
 
 export default SignInPage;

--- a/src/Pages/SignInPage/index.jsx
+++ b/src/Pages/SignInPage/index.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 
 import NavBar from 'Components/Common/NavBar';
 import SignInContainer from 'Components/Sign/SignInContainer';
-import RoundLoader from 'Components/Loader/Round';
 
 class SignInPage extends Component {
   constructor(props) {
@@ -24,7 +23,6 @@ class SignInPage extends Component {
             <a href="/signup">Sign Up</a>
           </div>
         </div>
-        <RoundLoader />
       </>
     );
   }

--- a/src/Pages/SignInPage/index.jsx
+++ b/src/Pages/SignInPage/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import NavBar from 'Components/Common/NavBar';
 import SignInContainer from 'Components/Sign/SignInContainer';
+import RoundLoader from 'Components/Loader/Round';
 
 class SignInPage extends Component {
   constructor(props) {
@@ -22,6 +23,7 @@ class SignInPage extends Component {
             <span>Already have an account? </span>
             <a href="/signup">Sign Up</a>
           </div>
+          <RoundLoader />
         </div>
       </>
     );

--- a/src/Redux/auth.js
+++ b/src/Redux/auth.js
@@ -11,10 +11,14 @@ const POST_USER_FAIL = 'auth/POST_USER_FAIL';
 const GET_USER_SUCCESS = 'auth/GET_USER_SUCCESS';
 const GET_USER_FAIL = 'auth/GET_USER_FAIL';
 
+const SET_LOADING_TRUE = 'auth/SET_LOADING_TRUE';
+const SET_LOADING_FALSE = 'auth/SET_LOADING_FALSE';
+
 const initialState = {
   isLogin: !!localStorage.getItem('token'),
   token: localStorage.getItem('token'),
   user: null,
+  loading: false,
 };
 
 const setToken = createAction(SET_TOKEN); // result.data.token
@@ -23,6 +27,8 @@ const postUserSuccess = createAction(POST_USER_SUCCESS);
 const postUserFail = createAction(POST_USER_FAIL);
 const getUserSuccess = createAction(GET_USER_SUCCESS); // result.data
 const getUserFail = createAction(GET_USER_FAIL);
+const setLoadingTrue = createAction(SET_LOADING_TRUE);
+const setLoadingFalse = createAction(SET_LOADING_FALSE);
 
 export default authReducer(
   {
@@ -46,6 +52,12 @@ export default authReducer(
     [GET_USER_FAIL]: (state) => {
       localStorage.removeItem('token');
       return { ...state, isLogin: false, token: null, user: null };
+    },
+    [SET_LOADING_TRUE]: (state) => {
+      return { ...state, loading: true };
+    },
+    [SET_LOADING_FALSE]: (state) => {
+      return { ...state, loading: false };
     },
   },
   initialState,
@@ -134,5 +146,12 @@ export const getUser = (token) => {
     } catch (error) {
       await dispatch(getUserFail());
     }
+  };
+};
+
+export const setLoadingState = (makeLoading) => {
+  return (dispatch) => {
+    if (makeLoading) dispatch(setLoadingTrue());
+    else dispatch(setLoadingFalse());
   };
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -25,6 +25,7 @@
 @import 'Components/Post/PostFooter/FundFooter';
 @import 'Components/Post/PostFooter/ShopFooter';
 @import 'Components/Post/PostButton';
+@import 'Components/Loader/Round';
 /* Pages Style */
 @import 'Pages/GuidePage';
 @import 'Pages/MainPage';


### PR DESCRIPTION
<!-- 이 Pull Request에 대한 간략한 소개 -->

> ㅠㅠ 브랜치명을 feature/ 붙이는걸 깜빡했네유,,,

로그인 및 회원가입할 때 서버 요청 시간 동안 로딩을 넣어서 어색한 플로우를 개선합니다.

#### 관련 이슈 <!-- #[issue_number] -->

#55 [FEATURE] Sign In/Up Loading State

#### 변경 사항 <!-- 변경한 내용을 목록화하여 적어주세요. --> 

1. RoundLoader Component 생성  
(`Components/Loader/Round` 경로로 만들었는데, 추후 다양한 로더 이 경로에 생성하면 될 것 같아요 ~)
2. authReducer -> loading state 추가
2. 로그인 시작~완료 까지 로딩 추가 : SignInPage에 넣음
3. 회원가입 시작~완료 까지 로딩 추가 (로딩 후 다음 페이지로 reload) : SignUpContainer에 넣음  
(회원가입 폼은 FavoritePage에서 모달 형태로도 사용하기 때문에 로딩을 SignUpPage가 아닌 Container에 넣음)

![image](https://user-images.githubusercontent.com/22045163/103213533-4f818900-4951-11eb-8bd8-ffd9341fd9c4.png)
![image](https://user-images.githubusercontent.com/22045163/103213551-5e683b80-4951-11eb-813d-de974d0b0684.png)

![image](https://user-images.githubusercontent.com/22045163/103213465-13e6bf00-4951-11eb-8568-89e28cb97a47.png)
![image](https://user-images.githubusercontent.com/22045163/103213482-1ea15400-4951-11eb-8b75-f928e2eb47c0.png)

![image](https://user-images.githubusercontent.com/22045163/103213573-750e9280-4951-11eb-84ed-a68b2159266f.png)

#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

테스트 부탁드려요 ! 😎

#### Reference <!-- 참고할 링크 혹은 참고 사항을 정리해둔 이슈가 있다면 적어주세요. -->

- Loader 코드 참고 : [iOS, macOS Spinner (Pure CSS)](https://codepen.io/jmak/pen/LsCet)
- 다양한 Loader 디자인 참고 : [80+ Best Pure CSS Loading Spinners For Front-end Developers (2020 Update)](https://365webresources.com/best-pure-css-loading-spinners/)