### PR TITLE
Fix Issue(Refresh Button not works)

### DIFF
--- a/src/Components/Mix/MixProgress/index.jsx
+++ b/src/Components/Mix/MixProgress/index.jsx
@@ -25,11 +25,11 @@ const defaultProps = {};
 const propTypes = {};
 
 function MixProgress() {
-  const history = useHistory();
   const dispatch = useDispatch();
+  const history = useHistory();
   const mixState = useSelector((state) => state.postReducer.mixState);
   const user = useSelector((state) => state.authReducer.user);
-  const { progressIndex, isMixing, mixId, originId } = mixState;
+  const { progressIndex, isMixing, mixId } = mixState;
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState(false);
   const isMixEnd = () => {
@@ -44,7 +44,6 @@ function MixProgress() {
     dispatch(recomposeMixing());
     history.push({
       pathname: `/user/${user.nickname}`,
-      search: `?recompose=${originId}`,
     });
   };
 

--- a/src/Components/Post/PostButton/MixButton/index.jsx
+++ b/src/Components/Post/PostButton/MixButton/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getPostByPostId, startRecompose } from 'Redux/post';
+import { startRecompose } from 'Redux/post';
 
 import NoStyleButton from 'Components/Form/NoStyleButton';
 import MixHandler from 'Components/Mix/MixHandler';
@@ -23,7 +23,6 @@ function MixButton(props) {
   const [isOpen, setIsOpen] = useState(false);
   const [chosenSubPost, setChosenSubPost] = useState(null);
   const [chosenOriginPost, setChosenOriginPost] = useState(null);
-  const token = useSelector((state) => state.authReducer.token);
   const mixState = useSelector((state) => state.postReducer.mixState);
   const { isMixing, mixId, recomposeFlag, originId } = mixState;
   const useMountEffect = (func) => useEffect(func);

--- a/src/Components/Post/PostButton/MixButton/index.jsx
+++ b/src/Components/Post/PostButton/MixButton/index.jsx
@@ -4,6 +4,7 @@ import { startRecompose } from 'Redux/post';
 
 import NoStyleButton from 'Components/Form/NoStyleButton';
 import MixHandler from 'Components/Mix/MixHandler';
+import SignInModal from 'Components/Sign/SignInModal';
 
 import mixImage from 'Assets/images/mixButton.png';
 
@@ -23,15 +24,22 @@ function MixButton(props) {
   const [isOpen, setIsOpen] = useState(false);
   const [chosenSubPost, setChosenSubPost] = useState(null);
   const [chosenOriginPost, setChosenOriginPost] = useState(null);
+  const [openSignIn, setOpenSignin] = useState(false);
   const mixState = useSelector((state) => state.postReducer.mixState);
+  const isLogin = useSelector((state) => state.authReducer.isLogin);
   const { isMixing, mixId, recomposeFlag, originId } = mixState;
   const useMountEffect = (func) => useEffect(func);
 
   const toggle = () => {
-    const { originPost } = props;
-    if (isOpen) setChosenOriginPost(null);
-    else setChosenOriginPost(originPost);
-    setIsOpen(!isOpen);
+    console.log(isLogin, openSignIn);
+    if (isLogin) {
+      const { originPost } = props;
+      if (isOpen) setChosenOriginPost(null);
+      else setChosenOriginPost(originPost);
+      setIsOpen(!isOpen);
+    } else {
+      setOpenSignin(true);
+    }
   };
 
   const modalOnClose = () => {
@@ -56,6 +64,7 @@ function MixButton(props) {
   useMountEffect(() => {
     const { originPost } = props;
     if (recomposeFlag && originId && originId === originPost.id) recompose();
+    if (isLogin) setOpenSignin(false);
   });
 
   return (
@@ -63,7 +72,11 @@ function MixButton(props) {
       <NoStyleButton onClick={toggle}>
         <img className="postButton mix" src={mixImage} alt="mix" />
       </NoStyleButton>
-      {chosenOriginPost && (
+      <SignInModal
+        isOpen={openSignIn}
+        toggle={() => setOpenSignin(!openSignIn)}
+      />
+      {isLogin && chosenOriginPost && (
         <Modal
           isOpen={chosenOriginPost && isOpen && !(isMixing || mixId)}
           toggle={toggle}

--- a/src/Components/Post/PostButton/MixButton/index.jsx
+++ b/src/Components/Post/PostButton/MixButton/index.jsx
@@ -45,10 +45,13 @@ function MixButton(props) {
   };
 
   const recompose = async () => {
-    const post = await dispatch(getPostByPostId(originId, token));
-    setChosenOriginPost(post);
-    setIsOpen(true);
-    dispatch(startRecompose());
+    const { originPost } = props;
+    if (originPost) {
+      const post = originPost;
+      setChosenOriginPost(post);
+      setIsOpen(true);
+      dispatch(startRecompose());
+    }
   };
 
   useMountEffect(() => {

--- a/src/Components/Post/PostButton/MixButton/index.jsx
+++ b/src/Components/Post/PostButton/MixButton/index.jsx
@@ -31,7 +31,6 @@ function MixButton(props) {
   const useMountEffect = (func) => useEffect(func);
 
   const toggle = () => {
-    console.log(isLogin, openSignIn);
     if (isLogin) {
       const { originPost } = props;
       if (isOpen) setChosenOriginPost(null);

--- a/src/Components/Sign/SignInModal/index.jsx
+++ b/src/Components/Sign/SignInModal/index.jsx
@@ -1,18 +1,35 @@
 import React, { useState } from 'react';
 
+import PropTypes from 'prop-types';
+
 import { Modal } from 'reactstrap';
 import SignUpContainer from 'Components/Sign/SignUpContainer';
 
-function SignInModal() {
+function SignInModal(props) {
   const [modal, setModal] = useState(true);
-  const toggle = () => setModal(!modal);
-
+  const defaultToggle = () => setModal(!modal);
+  const { isOpen, toggle } = props;
   return (
-    <Modal className="signInModal" isOpen={modal} toggle={toggle} centered>
+    <Modal
+      className="signInModal"
+      isOpen={isOpen !== null ? isOpen : modal}
+      toggle={toggle || defaultToggle}
+      centered
+    >
       <div className="signInModal__header">Please log in and use it.</div>
       <SignUpContainer />
     </Modal>
   );
 }
+
+SignInModal.propTypes = {
+  isOpen: PropTypes.bool,
+  toggle: PropTypes.func,
+};
+
+SignInModal.defaultProps = {
+  isOpen: null,
+  toggle: null,
+};
 
 export default SignInModal;

--- a/src/Redux/post.js
+++ b/src/Redux/post.js
@@ -16,6 +16,7 @@ const initialState = {
     progressIndex: 0,
     progressInterval: null,
     originId: null,
+    recomposeFlag: false,
   },
   uploadState: {
     isUploading: false,
@@ -46,6 +47,7 @@ const MIX_POST_FAIL = 'post/MIX_POST_FAIL';
 
 const INCREASE_PB_INDEX = 'post/INCREASE_PB_INDEX';
 const RECOMPOSE_MIXING = 'post/RECOMPOSE_MIXING';
+const START_RECOMPOSE = 'post/START_RECOMPOSE';
 const START_MIX = 'post/START_MIX';
 const END_MIX = 'post/END_MIX';
 const INIT_MIXSTATE = 'post/INIT_MIXSTATE';
@@ -66,6 +68,7 @@ export const mixPostSuccess = createAction(MIX_POST_SUCCESS);
 export const mixPostFail = createAction(MIX_POST_FAIL);
 export const increasePbIndex = createAction(INCREASE_PB_INDEX);
 export const recomposeMixing = createAction(RECOMPOSE_MIXING);
+export const startRecompose = createAction(START_RECOMPOSE);
 export const uploadPostStart = createAction(UPLOAD_POST_START);
 export const startMix = createAction(START_MIX);
 export const endMix = createAction(END_MIX);
@@ -159,6 +162,16 @@ export default postReducer(
         mixState: {
           ...initialState.mixState,
           originId,
+          recomposeFlag: true,
+        },
+      };
+    },
+    [START_RECOMPOSE]: (state) => {
+      return {
+        ...state,
+        mixState: {
+          ...state.mixState,
+          recomposeFlag: false,
         },
       };
     },
@@ -354,9 +367,8 @@ export const mixPost = (originId, subId, token) => {
     try {
       const interval = setInterval(() => {
         dispatch(increasePbIndex());
-      }, 6000);
+      }, 1000);
       await dispatch(startMix({ originId, interval }));
-
       const response = await fetch(
         `${process.env.REACT_APP_SERVER_URL}${INIT}${MIX_API}/${originId}/${subId}`,
         {


### PR DESCRIPTION
<!-- 이 Pull Request에 대한 간략한 소개 -->

#### 관련 이슈 <!-- #[issue_number] -->
#68 

#### 변경 사항 <!-- 변경한 내용을 목록화하여 적어주세요. --> 
기존에는 리프레시 버튼 클릭 시 유저페이지로 query,parameter 넘겨  유저페이지에 구현되어 있는 location 변경 여부를 감지하는 리스너가 이를 감지해서 합성 모달을 띄우는 방식이었습니다.

Mix 브랜치 rebase 하는 과정에서 MixButton으로 해당 기능을 이전하는 과정에서 제대로 테스트를 해보지 못한 것 같습니다.

쿼리로 넘기는 방식 대신 리덕스에 재합성을 요청했는 지에 대한 flag 변수를 추가했습니다.
이에 따라 MixButton에서 
 1. originId와 props로 받은 본인의 postId와 같으며 ( == 재합성을 요청한 포스트의 믹스버튼인지 판별)
 2. recomposeFlag가 활성화 되어있는지 ( == 현재 재합성을 요청한 상태인지)

위와 같은 조건을 판별하여 재합성을 진행하도록 수정하였습니다.


#### PR Point <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

테스트 해보기가 조금 귀찮습니다.
mixPost() 액션 실행되었을 때, 서버로 요청을 보내는 부분부터 쭉~ 주석처리하고
바로 mixPostFail() 액션 실행시키면 빠르게 테스트가 가능합니다.

아니면 그냥 서버에서 response stauts 500줄 때까지 기다려도됩니다.

동작여부만 테스트해주시면 감사하겠습니다^_^

#### Reference <!-- 참고할 링크 혹은 참고 사항을 정리해둔 이슈가 있다면 적어주세요. -->

